### PR TITLE
core: Use Deno.Command instead of Deno.run - bump minimum Deno version to v1.31.1 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![deno module](https://shield.deno.dev/x/dkill)](https://deno.land/x/dkill)
-![deno compatibility](https://shield.deno.dev/deno/^1.29.1)
+![deno compatibility](https://shield.deno.dev/deno/^1.31.1)
 
 <h1 align="center">
   🎯 dkill

--- a/cli.test.ts
+++ b/cli.test.ts
@@ -1,48 +1,62 @@
 import { assertEquals, assertNotEquals, delay } from "./deps_test.ts";
 
 Deno.test("killing by pid", async () => {
-  // create pid
-  const pTest = Deno.run({
-    cmd: ["sleep", "5000"],
+  // create test process
+  const command = new Deno.Command("sleep", {
+    args: [
+      "5000",
+    ],
   });
+  const pTest = command.spawn();
+  await delay(100);
 
-  // call dkill
-  const pDkill = Deno.run({
-    cmd: ["deno", "run", "-A", "./cli.ts", `${pTest.pid}`],
+  const pKill = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "-A",
+      "./cli.ts",
+      `${pTest.pid}`,
+    ],
   });
-  // wait dkill finishes
-  const cliStatus = await pDkill.status();
+  const { code } = await pKill.output();
 
   // retreive status from test pid
-  const status = await pTest.status();
-
-  // close resources
-  pTest.close();
-  pDkill.close();
+  const status = await pTest.status;
 
   // ensure dkill existed cleanly
-  assertEquals(cliStatus.code, 0);
+  assertEquals(code, 0);
   assertNotEquals(status.code, 0);
 });
 
 Deno.test({
   name: "killing by ports",
   fn: async () => {
-    // create a webserver
-    const pTest1 = Deno.run({
-      cmd: ["deno", "run", "-A", "./src/tests/utils.ts"],
+    // create 2 webservers
+    const pTest1Cmd = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "-A",
+        "./src/tests/utils.ts",
+      ],
     });
-    const pTest2 = Deno.run({
-      cmd: ["deno", "run", "-A", "./src/tests/utils.ts", "8081"],
+
+    const pTest2Cmd = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "-A",
+        "./src/tests/utils.ts",
+        "8081",
+      ],
     });
+    const pTest1 = pTest1Cmd.spawn();
+    const pTest2 = pTest2Cmd.spawn();
 
     // give time fo the webserver to start and the port be discoverable
     await delay(5000);
 
     // call dkill
-    const pDkill = Deno.run({
-      cmd: [
-        "deno",
+    const pDkillCmd = new Deno.Command(Deno.execPath(), {
+      args: [
         "run",
         "-A",
         "--unstable",
@@ -52,20 +66,15 @@ Deno.test({
         ":8081",
       ],
     });
-    // wait dkill finishes
-    const cliStatus = await pDkill.status();
-    pDkill.close();
-    // ensure dkill exited cleanly
-    assertEquals(cliStatus.code, 0);
 
-    // throw Error('xxx')
+    // wait dkill finishes
+    const { code } = await pDkillCmd.output();
+    // ensure dkill exited cleanly
+    assertEquals(code, 0);
 
     // retrieve status from test pid
-    const status1 = await pTest1.status();
-    const status2 = await pTest2.status();
-    // close resources
-    pTest1.close();
-    pTest2.close();
+    const status1 = await pTest1.status;
+    const status2 = await pTest2.status;
 
     assertNotEquals(status1.code, 0);
     assertNotEquals(status1.code, 5); // check it wasn't a timeout

--- a/cli.test.ts
+++ b/cli.test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertNotEquals, delay } from "./deps_test.ts";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+  delay,
+} from "./deps_test.ts";
 
 Deno.test("killing by pid", async () => {
   // create test process
@@ -59,7 +64,6 @@ Deno.test({
       args: [
         "run",
         "-A",
-        "--unstable",
         "./cli.ts",
         "--verbose",
         ":8080",
@@ -81,4 +85,22 @@ Deno.test({
     assertNotEquals(status2.code, 0);
     assertNotEquals(status2.code, 5);
   },
+});
+
+Deno.test("Invalid ports", async () => {
+  // call dkill
+  const pDkillCmd = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "-A",
+      "./cli.ts",
+      ":8080",
+    ],
+  });
+
+  // wait dkill finishes
+  const { code, stdout } = await pDkillCmd.output();
+  // ensure dkill exited cleanly
+  assertEquals(code, 0);
+  assertStringIncludes(new TextDecoder().decode(stdout), "No process found");
 });

--- a/cli.ts
+++ b/cli.ts
@@ -7,9 +7,11 @@ import { assertMinVersion } from "./src/utils/versions.ts";
 import vJson from "./version.json" assert { type: "json" };
 
 // check minimum version of deno
-const minVRequired = "1.29.1";
+const minVRequired = "1.31.1"; // uses deno.Command
 if (!assertMinVersion(Deno.version.deno, minVRequired)) {
-  console.error(`Please upgrade deno. min version required: ${minVRequired}`);
+  console.error(
+    `Please upgrade deno. Minimum version required is: ${minVRequired}`,
+  );
   Deno.exit(1);
 }
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "test": "deno test --allow-run --allow-net",
+    "test": "deno test --allow-run --allow-net --allow-read",
     "testm": "deno run --allow-run --allow-net ./src/tests/utils.ts",
     "dev": "deno run --allow-run --allow-net ./cli.ts",
     "release": "deno run -A https://deno.land/x/release_up@0.5.0/cli.ts --regex \"(?<=@)(.*)(?=\/cli)\" --github --versionFile --changelog"

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -2,6 +2,7 @@ export {
   assert,
   assertEquals,
   assertNotEquals,
+  assertStringIncludes,
 } from "https://deno.land/std@0.170.0/testing/asserts.ts";
 export { delay } from "https://deno.land/std@0.170.0/async/mod.ts";
 export { serve } from "https://deno.land/std@0.170.0/http/server.ts";

--- a/src/utils/runCmd.ts
+++ b/src/utils/runCmd.ts
@@ -1,12 +1,13 @@
 export async function runCmd(cmd: string[], verbose?: boolean) {
   verbose && console.log(cmd.join(" "));
-  const exec = Deno.run({
-    cmd,
-    stdout: "piped",
-    stderr: "piped",
+  const [cmd1, ...cmd2] = cmd;
+
+  const exec = new Deno.Command(cmd1, {
+    args: cmd2,
+    stderr: "inherit",
   });
 
-  const out = await exec.output();
-  exec.close();
-  return new TextDecoder().decode(out);
+  const { code, stdout } = await exec.output();
+  if (code !== 0) throw Error(`fail executing ${cmd.join(" ")}`);
+  return new TextDecoder().decode(stdout);
 }

--- a/src/utils/runCmd.ts
+++ b/src/utils/runCmd.ts
@@ -1,3 +1,7 @@
+/**
+ * Return the stdout of the command.
+ * This does not throw if the code return is non zero.
+ */
 export async function runCmd(cmd: string[], verbose?: boolean) {
   verbose && console.log(cmd.join(" "));
   const [cmd1, ...cmd2] = cmd;

--- a/src/utils/runCmd.ts
+++ b/src/utils/runCmd.ts
@@ -7,7 +7,6 @@ export async function runCmd(cmd: string[], verbose?: boolean) {
     stderr: "inherit",
   });
 
-  const { code, stdout } = await exec.output();
-  if (code !== 0) throw Error(`fail executing ${cmd.join(" ")}`);
+  const { stdout } = await exec.output();
   return new TextDecoder().decode(stdout);
 }


### PR DESCRIPTION
Deno.run is being deprecated and the recommendation is to use Deno.Command. https://deno.com/blog/v1.31#api-stabilizations